### PR TITLE
Fix PNG height

### DIFF
--- a/miniz_tdef.c
+++ b/miniz_tdef.c
@@ -1490,7 +1490,7 @@ void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int 
         pnghdr[18] = (mz_uint8)(w >> 8);
         pnghdr[19] = (mz_uint8)w;
         pnghdr[22] = (mz_uint8)(h >> 8);
-        pnghdr[22] = (mz_uint8)h;
+        pnghdr[23] = (mz_uint8)h;
         pnghdr[25] = chans[num_chans];
         pnghdr[33] = (mz_uint8)(*pLen_out >> 24);
         pnghdr[34] = (mz_uint8)(*pLen_out >> 16);


### PR DESCRIPTION
Fixed array index where to store image height.
PNG files made using `tdefl_write_image_to_png_file_in_memory_ex()` were very tall, with a huge empty area at the end.

Since `pnghdr[22]` was assigned twice, I changed indices to store height exactly in the way width is stored (two consecutive swapped bytes). Now PNG file height is correct.